### PR TITLE
Fix path handling of buffers in RunGrepSpecial (forwarded by email to script author)

### DIFF
--- a/plugin/grep.vim
+++ b/plugin/grep.vim
@@ -618,7 +618,10 @@ function! s:RunGrepSpecial(cmd_name, which, action, ...)
 
         while i <= last_bufno
             if bufexists(i) && buflisted(i)
-                let filenames = filenames . " " . bufname(i)
+                let full_path = fnamemodify(bufname(i), ':p')
+                if filereadable(full_path)
+                    let filenames = filenames . " " . fnameescape(full_path)
+                endif
             endif
             let i = i + 1
         endwhile


### PR DESCRIPTION
1. use fnamemodify to get the absolute pathname of the buffer
2. use filereadable to test for its existence
3. escape it using fnameescape.
